### PR TITLE
ceph_mon.cc: add feature "CEPH_FEATURE_MSGR_KEEPALIVE2" for client

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -676,7 +676,7 @@ int main(int argc, const char **argv)
     CEPH_FEATURE_MONCLOCKCHECK |
     CEPH_FEATURE_PGID64 |
     CEPH_FEATURE_MSG_AUTH
-    CEPH_FEATURE_MSGR_KEEPALIVE2;
+    CEPH_FEATURE_MSGR_KEEPALIVE2 ;
   msgr->set_default_policy(Messenger::Policy::stateless_server(supported, 0));
   msgr->set_policy(entity_name_t::TYPE_MON,
                    Messenger::Policy::lossless_peer_reuse(

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -675,7 +675,8 @@ int main(int argc, const char **argv)
     CEPH_FEATURE_NOSRCADDR |
     CEPH_FEATURE_MONCLOCKCHECK |
     CEPH_FEATURE_PGID64 |
-    CEPH_FEATURE_MSG_AUTH;
+    CEPH_FEATURE_MSG_AUTH
+    CEPH_FEATURE_MSGR_KEEPALIVE2;
   msgr->set_default_policy(Messenger::Policy::stateless_server(supported, 0));
   msgr->set_policy(entity_name_t::TYPE_MON,
                    Messenger::Policy::lossless_peer_reuse(


### PR DESCRIPTION
add feature "CEPH_FEATURE_MSGR_KEEPALIVE2" for client to avoid client stuck forever

Fixes: #14340
Signed-off-by: shun song song.shun3@zte.com.cn
