### PR TITLE
init-ceph.in:  wipe out time limit of adding osd into crush map

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -403,7 +403,7 @@ for name in $what; do
 		    get_conf osd_weight "" "osd crush initial weight"
 		    defaultweight="$(df -P -k $osd_data/. | tail -1 | awk '{ print sprintf("%.4f",$2/1073741824) }')"
 		    get_conf osd_keyring "$osd_data/keyring" "keyring"
-		    do_cmd_okfail "timeout 30 $BINDIR/ceph -c $conf --name=osd.$id --keyring=$osd_keyring osd crush create-or-move -- $id ${osd_weight:-${defaultweight:-1}} $osd_location"
+		    do_cmd_okfail "$BINDIR/ceph -c $conf --name=osd.$id --keyring=$osd_keyring osd crush create-or-move -- $id ${osd_weight:-${defaultweight:-1}} $osd_location"
 		    if [ "$ERR" != "0" ]; then
 			EXIT_STATUS=$ERR
 			continue


### PR DESCRIPTION
wipe out time limit 30s of adding osd into crush map when starting osd or restart osd

Signed-off-by: song shun song.shun2@zte.com.cn
